### PR TITLE
jupyter_events 0.12.0: rebuild for py314

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  number: 0
+  number: 1
   skip: True # [py<39]
   entry_points:
     - jupyter-events = jupyter_events.cli:main
@@ -41,6 +41,7 @@ test:
     - pip
     - pytest >=7.0
     - pytest-asyncio >=0.19.0
+    - pytest-tornasync
     - pytest-console-scripts
   commands:
     - pip check


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-11336) 
- [Upstream repository](https://github.com/jupyter/jupyter_events/tree/v0.12.0)

### Explanation of changes:

- Add `python-tornasync` to suppress an error `async def functions are not natively supported.`

### Notes:

-